### PR TITLE
OPS-1281 - Updating kubectl binary to 1.15.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
-FROM kayosportsau/ubuntu-base:1.0.15
+FROM kayosportsau/ubuntu-base:1.0.17
 
-ARG KUBECTL_VERSION=v1.14.9
+ARG KUBECTL_VERSION=v1.15.12
 ARG JX_VERSION=v2.0.800
 ARG EKSCTL_VERSION=latest_release
 ARG KUSTOMIZE_VERSION=2.0.3


### PR DESCRIPTION
This is just 1 of probably 2 PRs. Once this builds I will need to update `docker-ubuntu-aws-cli` with the new tagged output of this.

I also included an update for `kayosportsau/ubuntu-base` as I saw there was a new tagged version.

I have built and tested it locally. Both `docker-ubuntu-devops-base` and `docker-ubuntu-aws-cli` using the local image.