### PR TITLE
Helper script to select AWS profile

### DIFF
--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -3,8 +3,9 @@
 AWS_CONFIG_FILE=${AWS_CONFIG_FILE:-"$HOME/.aws/config"} 
 
 usage() {
-  echo "Usage: source $0"
+  echo "Usage: source $0 [SEARCH]"
   echo "A script that selects an AWS profile"
+  echo "SEARCH does a fuzzy match on the profile name"
   exit 1
 }
 
@@ -24,13 +25,22 @@ check_sourced() {
 }
 
 select_profile() {
+    local search=$1
+    local capture
+    local regex
+    if [ -n "$search" ]; then
+        capture="${search}.*"
+    fi
+    
     echo "Fetching profiles from $AWS_CONFIG_FILE"
+
+    regex="(?<=^\[profile )(.*${capture})(?=\])"
 
     # Zsh requires slightly different data structures
     if [ -n "$BASH" ]; then
-        profiles=$(grep -oP "(?<=^\[profile )(.*)(?=\])" $AWS_CONFIG_FILE)
+        profiles=$(grep -oP $regex $AWS_CONFIG_FILE)
     elif [ -n "$ZSH_NAME" ]; then
-        profiles=($(grep -oP "(?<=^\[profile )(.*)(?=\])" $AWS_CONFIG_FILE))
+        profiles=($(grep -oP $regex $AWS_CONFIG_FILE))
     fi
     
     select profile in $profiles
@@ -41,6 +51,7 @@ select_profile() {
     done
 }
 
+usage
 check_sourced
 check_deps || return
-select_profile
+select_profile $1

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -35,15 +35,10 @@ select_profile() {
     echo "Fetching profiles from $AWS_CONFIG_FILE"
 
     regex="(?<=^\[profile )(.*${inner_regex})(?=\])"
-
-    # Zsh requires slightly different data structures
-    if [ -n "$BASH" ]; then
-        profiles=$(grep -oP "$regex" "$AWS_CONFIG_FILE")
-    elif [ -n "$ZSH_NAME" ]; then
-        profiles=($(grep -oP "$regex" "$AWS_CONFIG_FILE"))
-    fi
-    
-    select profile in $profiles
+    profiles=()
+    while IFS='' read -r line; do profiles+=("$line"); done < <(grep -oP "$regex" "$AWS_CONFIG_FILE")
+   
+    select profile in  "${profiles[@]}"
     do
         echo "You have selected $profile"
         export AWS_PROFILE="$profile"

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -38,9 +38,9 @@ select_profile() {
 
     # Zsh requires slightly different data structures
     if [ -n "$BASH" ]; then
-        profiles=$(grep -oP $regex $AWS_CONFIG_FILE)
+        profiles=$(grep -oP "$regex" "$AWS_CONFIG_FILE")
     elif [ -n "$ZSH_NAME" ]; then
-        profiles=($(grep -oP $regex $AWS_CONFIG_FILE))
+        profiles=($(grep -oP "$regex" "$AWS_CONFIG_FILE"))
     fi
     
     select profile in $profiles
@@ -53,4 +53,4 @@ select_profile() {
 
 check_sourced
 check_deps || return
-select_profile $1
+select_profile "$1"

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -51,7 +51,6 @@ select_profile() {
     done
 }
 
-usage
 check_sourced
 check_deps || return
 select_profile $1

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -9,8 +9,9 @@ usage() {
   exit 1
 }
 
-check_deps() {
-    if [[ -z $(grep --version | grep 'GNU grep') ]]; then
+check_dependencies() {
+    if ! grep --version | grep 'GNU grep' 
+    then
         echo "Please use GNU grep. brew install grep"
         return 1
     fi
@@ -47,5 +48,5 @@ select_profile() {
 }
 
 check_sourced
-check_deps || return
+check_dependencies || return
 select_profile "$1"

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+
+AWS_CONFIG_FILE=${AWS_CONFIG_FILE:-"$HOME/.aws/config"} 
+
+usage() {
+  echo "Usage: source $0"
+  echo "A script that selects an AWS profile"
+  exit 1
+}
+
+check_deps() {
+    if [ -z $(grep --version | grep 'GNU grep') ]; then
+        echo "Please use GNU grep. brew install grep"
+        return 1
+    fi
+}
+
+check_sourced() {
+    [[ -n $ZSH_EVAL_CONTEXT && $ZSH_EVAL_CONTEXT =~ :file$ ]] || [ "$0" != "${BASH_SOURCE[0]}" ] && sourced=1 || sourced=0
+    if [ $sourced -eq 0 ]; then
+        echo "Please source not execute this script"
+        usage
+    fi
+}
+
+select_profile() {
+    echo "Fetching profiles from $AWS_CONFIG_FILE"
+    
+    # Zsh requires slightly different data structures
+    if [ -n "$BASH" ]; then
+        profiles=$(grep -oP "(?<=^\[profile )(.*)(?=\])" $AWS_CONFIG_FILE)
+    elif [ -n "$ZSH_NAME" ]; then
+        profiles=($(grep -oP "(?<=^\[profile )(.*)(?=\])" $AWS_CONFIG_FILE))
+    fi
+    
+    select profile in $profiles
+    do
+        echo "You have selected $profile"
+        export AWS_PROFILE="$profile"
+        break
+    done
+}
+
+check_sourced
+check_deps || return
+select_profile

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -9,7 +9,7 @@ usage() {
 }
 
 check_deps() {
-    if [ -z $(grep --version | grep 'GNU grep') ]; then
+    if [[ -z $(grep --version | grep 'GNU grep') ]]; then
         echo "Please use GNU grep. brew install grep"
         return 1
     fi
@@ -25,7 +25,7 @@ check_sourced() {
 
 select_profile() {
     echo "Fetching profiles from $AWS_CONFIG_FILE"
-    
+
     # Zsh requires slightly different data structures
     if [ -n "$BASH" ]; then
         profiles=$(grep -oP "(?<=^\[profile )(.*)(?=\])" $AWS_CONFIG_FILE)

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -10,7 +10,7 @@ usage() {
 }
 
 check_dependencies() {
-    if ! grep --version | grep 'GNU grep' 
+    if ! grep --version | grep -q 'GNU grep' 
     then
         echo "Please use GNU grep. brew install grep"
         return 1

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -26,15 +26,15 @@ check_sourced() {
 
 select_profile() {
     local search=$1
-    local capture
+    local inner_regex
     local regex
     if [ -n "$search" ]; then
-        capture="${search}.*"
+        inner_regex="${search}.*"
     fi
     
     echo "Fetching profiles from $AWS_CONFIG_FILE"
 
-    regex="(?<=^\[profile )(.*${capture})(?=\])"
+    regex="(?<=^\[profile )(.*${inner_regex})(?=\])"
 
     # Zsh requires slightly different data structures
     if [ -n "$BASH" ]; then

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -37,7 +37,7 @@ select_profile() {
 
     regex="(?<=^\[profile )(.*${inner_regex})(?=\])"
     profiles=()
-    while IFS='' read -r line; do profiles+=("$line"); done < <(grep -oP "$regex" "$AWS_CONFIG_FILE")
+    while IFS='' read -r line; do profiles+=("$line"); done < <(grep -oP "$regex" "$AWS_CONFIG_FILE" | sort)
    
     PS3="Select a profile (1-${#profiles[@]}): "
     select profile in  "${profiles[@]}"

--- a/add/dev-cheats/select-aws-profile
+++ b/add/dev-cheats/select-aws-profile
@@ -39,6 +39,7 @@ select_profile() {
     profiles=()
     while IFS='' read -r line; do profiles+=("$line"); done < <(grep -oP "$regex" "$AWS_CONFIG_FILE")
    
+    PS3="Select a profile (1-${#profiles[@]}): "
     select profile in  "${profiles[@]}"
     do
         echo "You have selected $profile"


### PR DESCRIPTION
This script sets the `AWS_PROFILE` environment variable in your shell, I got sick of doing it manually.

If you find this handy, please share it around 😄  Improvements welcome!

Some key points:

- Supports bash and zsh.
- Supports adding a parameter so that you can search
- Supports `AWS_CONFIG_FILE` environment variable if not the default
- Requires installation of GNU grep. Has a check in the script for it. (is already in the docker image)
- I like to use this locally as well as in the docker image `cp add/dev-cheats/select-aws-profile /usr/local/bin/select-aws-profile && echo "alias sap='source select-aws-profile'" >> ~/.zshrc`  then use it as `sap` instead of `source select-aws-profile`

Example:
```
➜  ~ source select-aws-profile platform
Fetching profiles from /Users/Mitchell.Rowling/.aws/config
1) streamotion-platform-nonprod                   2) streamotion-platform-prod                      3) streamotion-platform-nonprod-drspike
Select a profile (1-3): 1
You have selected streamotion-platform-nonprod
```
```
➜  ~ source select-aws-profile
Fetching profiles from /Users/Mitchell.Rowling/.aws/config
1) foxsports-organisation                         12) foxsports-domestic-nonprod                    23) martian-vimond-nonprod                        34) streamotion-vimond-nonprod
2) shared-services                                13) foxsports-mam-dev                             24) martian-vimond-obsolete                       35) streamotion-vimond-prod
3) foxsports-monitoring-prod                      14) foxsports-mam-nonprod                         25) martian-vimond-prod                           36) streamotion-video-nonprod
4) foxsports-monitoring-dev                       15) foxsports-mam-prod                            26) foxsports-gitops                              37) streamotion-video-prod
5) foxsports-security                             16) foxsports-olympus-prod                        27) foxsports-audit                               38) streamotion-datalake-dev
6) foxsports-dr                                   17) foxsports-olympus-nonprod                     28) foxsports-identity                            39) streamotion-datalake-nonprod
7) martian-data-lake-dev                          18) international-ott-nonprod                     29) foxsports-gitops-dev                          40) streamotion-datalake-prod
8) martian-data-lake-nonprod                      19) international-ott-prod                        30) foxsports-gitops-test                         41) streamotion-platform-nonprod-drspike
9) martian-data-lake-prod                         20) martian-foxsports-nonprod                     31) streamotion-platform-nonprod
10) foxsports-sandbox                             21) martian-foxsports-prod                        32) streamotion-platform-prod
11) foxsports-domestic-prod                       22) martian-vimond-dev                            33) dev
Select a profile (1-41): 10
You have selected foxsports-sandbox
```