### PR TITLE
OPS-1972 Update boto3, so it will work with recent EKS platforms

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,8 +36,8 @@ RUN apt-get update && \
         troposphere==2.6.2 \
         cfn-flip==1.2.2 \
         colorama==0.3.9 \
-        boto3==1.14.47 \
-        botocore==1.17.47 \
+        boto3==1.16.25 \
+        botocore==1.16.25 \
         sceptre-aws-resolver==0.4 \
         sceptre-minify-file-contents-resolver==0.0.2 
 


### PR DESCRIPTION
OPS-1972 Update boto3, so it will work with recent EKS platforms

Notes:
EKS platform != kubernetes version
Strangely boto3 in the current image is 1.9.94- which doesn't match the dockerfile


